### PR TITLE
remove double type produced from the enforce-proxy-configuration rule

### DIFF
--- a/src/rules/enforce-proxy-configuration-type.ts
+++ b/src/rules/enforce-proxy-configuration-type.ts
@@ -58,7 +58,6 @@ const enforceProxyConfigurationType: Rule.RuleModule = {
         if (configVariableName && !hasProxyConfigurationImport && importNode && configNode) {
           const declarator = configNode.declarations[0] as VariableDeclarator;
 
-          // Check if the type annotation exists (this is a TypeScript feature, so it may not be present)
           const hasTypeAnnotation =
             'typeAnnotation' in declarator.id && !!(declarator.id as any).typeAnnotation;
 

--- a/src/rules/enforce-proxy-configuration-type.ts
+++ b/src/rules/enforce-proxy-configuration-type.ts
@@ -23,23 +23,32 @@ const enforceProxyConfigurationType: Rule.RuleModule = {
         if (node.source.value === '../../models') {
           importNode = node;
           hasProxyConfigurationImport = node.specifiers.some(
-            (specifier) => specifier.type === 'ImportSpecifier' && 
-                           'imported' in specifier &&
-                           specifier.imported.type === 'Identifier' && 
-                           specifier.imported.name === 'ProxyConfiguration'
+            (specifier) =>
+              specifier.type === 'ImportSpecifier' &&
+              'imported' in specifier &&
+              specifier.imported.type === 'Identifier' &&
+              specifier.imported.name === 'ProxyConfiguration'
           );
         }
       },
       VariableDeclaration(node: VariableDeclaration) {
         const declarator = node.declarations[0] as VariableDeclarator;
-        if (declarator && declarator.type === 'VariableDeclarator' && 
-            declarator.id.type === 'Identifier' && declarator.init && 
-            declarator.init.type === 'ObjectExpression') {
+        if (
+          declarator &&
+          declarator.type === 'VariableDeclarator' &&
+          declarator.id.type === 'Identifier' &&
+          declarator.init &&
+          declarator.init.type === 'ObjectExpression'
+        ) {
           const properties = declarator.init.properties;
-          if (properties.some((prop): prop is Property => 
-              prop.type === 'Property' && 
-              prop.key.type === 'Identifier' && 
-              prop.key.name === 'endpoint')) {
+          if (
+            properties.some(
+              (prop): prop is Property =>
+                prop.type === 'Property' &&
+                prop.key.type === 'Identifier' &&
+                prop.key.name === 'endpoint'
+            )
+          ) {
             configVariableName = declarator.id.name;
             configNode = node;
           }
@@ -47,32 +56,38 @@ const enforceProxyConfigurationType: Rule.RuleModule = {
       },
       'Program:exit'() {
         if (configVariableName && !hasProxyConfigurationImport && importNode && configNode) {
-          context.report({
-            node: context.getSourceCode().ast,
-            message: 'ProxyConfiguration type should be imported and used for Nango API call configurations',
-            fix(fixer) {
-              const fixes = [];
+          const declarator = configNode.declarations[0] as VariableDeclarator;
 
-              if (importNode && importNode.specifiers.length > 0) {
-                fixes.push(fixer.insertTextAfter(
-                  importNode.specifiers[importNode.specifiers.length - 1], 
-                  ', ProxyConfiguration'
-                ));
-              }
+          // Check if the type annotation exists (this is a TypeScript feature, so it may not be present)
+          const hasTypeAnnotation =
+            'typeAnnotation' in declarator.id && !!(declarator.id as any).typeAnnotation;
 
-              if (configNode && configNode.declarations.length > 0) {
-                const configDeclarator = configNode.declarations[0] as VariableDeclarator;
-                if (configDeclarator && configDeclarator.id.type === 'Identifier') {
-                  fixes.push(fixer.insertTextAfter(
-                    configDeclarator.id, 
-                    ': ProxyConfiguration'
-                  ));
+          if (declarator.id.type === 'Identifier' && !hasTypeAnnotation) {
+            context.report({
+              node: context.getSourceCode().ast,
+              message: 'ProxyConfiguration type should be imported and used for Nango API call configurations',
+              fix(fixer) {
+                const fixes = [];
+
+                if (importNode && importNode.specifiers.length > 0) {
+                  fixes.push(
+                    fixer.insertTextAfter(
+                      importNode.specifiers[importNode.specifiers.length - 1],
+                      ', ProxyConfiguration'
+                    )
+                  );
                 }
-              }
 
-              return fixes;
-            },
-          });
+                if (declarator && declarator.id.type === 'Identifier') {
+                  fixes.push(
+                    fixer.insertTextAfter(declarator.id, ': ProxyConfiguration')
+                  );
+                }
+
+                return fixes;
+              },
+            });
+          }
         }
       },
     };


### PR DESCRIPTION
Prevents:

```
const config: PaginationParams: ProxyConfiguration = {
        endpoint: '/admin/users/list/active',
        params: {
            order: 'created',
            asc: 'true',
            stats: true // Additional parameters for the API request can be added in here
        }
    };

```